### PR TITLE
Use more suitanle handler

### DIFF
--- a/lib/activeadmin-orderable.rb
+++ b/lib/activeadmin-orderable.rb
@@ -19,7 +19,7 @@ module ActiveAdmin
     end
 
     module TableMethods
-      HANDLE = '&#x2195;'.html_safe
+      HANDLE = '&#9776;'.html_safe
 
       def orderable_handle_column options = {}
         column '', :class => "activeadmin-orderable" do |resource|


### PR DESCRIPTION
Hi, Jonathan, I think this symbol is more suitable for handler. What do you think?

![2015-09-10 11 34 59](https://cloud.githubusercontent.com/assets/991265/9783857/05d2f0c0-57b0-11e5-9cf1-f662ade45f1a.png)

Another option is to make it configurable using `#orderable_handle_column`'s options
